### PR TITLE
On Windows, prevent tempfiles from being deleted prior to reading.

### DIFF
--- a/src/artl_mcp/utils/doi_fetcher.py
+++ b/src/artl_mcp/utils/doi_fetcher.py
@@ -2,6 +2,7 @@ import re
 from typing import Any
 
 import requests
+import os
 from pydantic import BaseModel, Field
 
 
@@ -228,12 +229,21 @@ class DOIFetcher:
 
         from pdfminer.high_level import extract_text
 
+        temp_pdf_path = None
+        text_results = None
+
         try:
-            with tempfile.NamedTemporaryFile(suffix=".pdf", delete=True) as temp_pdf:
+            with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as temp_pdf:
                 temp_pdf.write(response.content)
                 temp_pdf.flush()
-                text = extract_text(temp_pdf.name)
-                return text.strip() if text else None
+                temp_pdf_path = temp_pdf.name
+                text = extract_text(temp_pdf_path)
+                text_results = text.strip() if text else None
         except Exception as e:
-            print(f"Error extracting PDF text: {e}")
+            print(f"Error extracting PDF text: {e} from {temp_pdf_path}")
             return None
+        finally:
+            if temp_pdf_path and os.path.exists(temp_pdf_path):
+                os.remove(temp_pdf_path)
+
+        return text_results

--- a/src/artl_mcp/utils/pdf_fetcher.py
+++ b/src/artl_mcp/utils/pdf_fetcher.py
@@ -1,6 +1,7 @@
 import tempfile
 
 import requests
+import os
 from pdfminer.high_level import extract_text
 from pdfminer.pdfparser import PDFSyntaxError
 
@@ -13,13 +14,23 @@ def extract_text_from_pdf(pdf_url: str) -> str:
     if response.status_code != 200:
         return "Error: Unable to retrieve PDF."
 
+    temp_pdf_path = None
+    text_results = None
+
     try:
-        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=True) as temp_pdf:
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as temp_pdf:
             temp_pdf.write(response.content)
             temp_pdf.flush()  # Ensure all data is written before reading
 
-            text = extract_text(temp_pdf.name)
-            return text.strip() if text else "Error: No text extracted from PDF."
+            temp_pdf_path = temp_pdf.name
+            text = extract_text(temp_pdf_path)
+            text_results = text.strip() if text else "Error: No text extracted from PDF."
 
     except (OSError, PDFSyntaxError) as e:
         return f"Error extracting PDF text: {e}"
+
+    finally:
+        if temp_pdf_path and os.path.exists(temp_pdf_path):
+            os.remove(temp_pdf_path)
+
+    return text_results


### PR DESCRIPTION
Fixes #111 

Tested on Windows 11:

```
============================== 5 passed in 3.15s ==============================
PASSED                 [ 20%]PASSED                     [ 40%]Available attributes: ['clean_text', 'email', 'get_full_text', 'get_full_text_info', 'get_metadata', 'get_unpaywall_info', 'headers', 'text_from_pdf_url']
PASSED                  [ 60%]Potential fetching methods: []
PASSED                            [ 80%]PASSED                                       [100%]
Process finished with exit code 0

```