### PR TITLE
Fix PMID type error in pubmed_utils.py

### DIFF
--- a/src/artl_mcp/utils/doi_fetcher.py
+++ b/src/artl_mcp/utils/doi_fetcher.py
@@ -1,8 +1,8 @@
+import os
 import re
 from typing import Any
 
 import requests
-import os
 from pydantic import BaseModel, Field
 
 

--- a/src/artl_mcp/utils/pdf_fetcher.py
+++ b/src/artl_mcp/utils/pdf_fetcher.py
@@ -1,7 +1,7 @@
+import os
 import tempfile
 
 import requests
-import os
 from pdfminer.high_level import extract_text
 from pdfminer.pdfparser import PDFSyntaxError
 
@@ -24,7 +24,9 @@ def extract_text_from_pdf(pdf_url: str) -> str:
 
             temp_pdf_path = temp_pdf.name
             text = extract_text(temp_pdf_path)
-            text_results = text.strip() if text else "Error: No text extracted from PDF."
+            text_results = (
+                text.strip() if text else "Error: No text extracted from PDF."
+            )
 
     except (OSError, PDFSyntaxError) as e:
         return f"Error extracting PDF text: {e}"

--- a/src/artl_mcp/utils/pubmed_utils.py
+++ b/src/artl_mcp/utils/pubmed_utils.py
@@ -127,7 +127,7 @@ def get_pmcid_text(pmcid: str) -> str:
     return get_pmid_text(pmid)
 
 
-def get_pmid_text(pmid: str) -> str:
+def get_pmid_text(pmid: str | int) -> str:
     """Fetch full text from PubMed Central Open Access BioC XML.
     If full text is not available, fallback to fetching the abstract from PubMed.
 
@@ -147,6 +147,7 @@ def get_pmid_text(pmid: str) -> str:
         The full text of the article if available, otherwise the abstract.
 
     """
+    pmid = str(pmid)
     if ":" in pmid:
         pmid = pmid.split(":")[1]
     text = get_full_text_from_bioc(pmid)


### PR DESCRIPTION
Convert pmid parameter to string in get_pmid_text function and update type annotation to accept both str and int. This fixes the TypeError that occurred when integer PMIDs were passed from get_pmid_from_pmcid function.

🤖 Generated with [Claude Code](https://claude.ai/code)