### PR TITLE
Add version reporting feature like landuse-mcp and nmdc-mcp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-.PHONY: test-coverage clean install dev format lint all server doi-test-query upload-test upload release deptry mypy search-test-query cli-demo-search-papers cli-demo-search-recent
+.PHONY: test-coverage clean install dev format lint all server doi-test-query upload-test upload release deptry mypy search-test-query cli-demo-search-papers cli-demo-search-recent test-version
 
 # Default target
-all: clean install dev test-coverage format lint mypy deptry build doi-test-query search-test-query
+all: clean install dev test-coverage format lint mypy deptry build doi-test-query search-test-query test-version
 
 # Install everything for development
 dev:
@@ -136,3 +136,8 @@ cli-demo-clean-text:
 # List all available CLI commands
 cli-list:
 	artl-cli --help
+
+# Test version flag
+test-version:
+	@echo "🔢 Testing version flag..."
+	uv run artl-mcp --version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ Issues = "https://github.com/contextualizer-ai/artl-mcp/issues"
 Documentation = "https://github.com/contextualizer-ai/artl-mcp#readme"
 
 [project.scripts]
-artl-mcp = "artl_mcp.main:cli"
+artl-mcp = "artl_mcp.__main__:main"
 artl-cli = "artl_mcp.cli:cli"
 
 [tool.hatch.version]

--- a/src/artl_mcp/__main__.py
+++ b/src/artl_mcp/__main__.py
@@ -1,0 +1,4 @@
+from .main import main
+
+if __name__ == "__main__":
+    main()

--- a/src/artl_mcp/main.py
+++ b/src/artl_mcp/main.py
@@ -1,4 +1,6 @@
 import asyncio
+import sys
+from importlib import metadata
 
 import click
 from fastmcp import FastMCP
@@ -30,6 +32,11 @@ from artl_mcp.tools import (
     search_pubmed_for_pmids,
     search_recent_papers,
 )
+
+try:
+    __version__ = metadata.version("artl-mcp")
+except metadata.PackageNotFoundError:
+    __version__ = "unknown"
 
 
 def create_mcp():
@@ -101,7 +108,7 @@ def cli(doi_query, pmid_search, max_results):
             "Error: Cannot use both --doi-query and --pmid-search simultaneously. "
             "Please use only one option at a time."
         )
-    
+
     if doi_query:
         # Run the client in asyncio
         asyncio.run(run_client(doi_query, mcp))
@@ -127,5 +134,13 @@ def cli(doi_query, pmid_search, max_results):
         mcp.run()
 
 
-if __name__ == "__main__":
+def main():
+    """Main entry point for the application."""
+    if "--version" in sys.argv:
+        print(__version__)
+        sys.exit(0)
     cli()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Add __main__.py entry point for consistent project structure
- Implement --version flag support using importlib.metadata
- Update pyproject.toml to use __main__:main entry point (keeping artl-cli intact)
- Add test-version target to Makefile and include in all target
- Version automatically determined from package metadata
- Follows same pattern as sibling projects for consistency

Usage: uv run artl-mcp --version or make test-version

🤖 Generated with [Claude Code](https://claude.ai/code)