### PR TITLE
Fix trusted publishing by removing environment requirement

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -34,7 +34,6 @@ jobs:
   build-and-publish:
     needs: test
     runs-on: ubuntu-latest
-    environment: pypi  # Use environment for additional protection
     permissions:
       contents: read
       id-token: write  # Required for trusted publishing


### PR DESCRIPTION
Remove the 'environment: pypi' configuration from the GitHub workflow since no environment is intended to be used. This fixes the trusted publisher configuration mismatch that was causing the publishing failure.

The token claim will now be:
- sub: repo:contextualizer-ai/artl-mcp:ref:refs/tags/v0.19.0

Instead of:
- sub: repo:contextualizer-ai/artl-mcp:environment:pypi

This should match the PyPI trusted publisher configuration.

🤖 Generated with [Claude Code](https://claude.ai/code)