### PR TITLE
Add email secret to PyPI publishing workflow test step

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -29,6 +29,8 @@ jobs:
         run: uv sync --group dev
 
       - name: Run tests
+        env:
+          ARTL_EMAIL_ADDR: ${{ secrets.ARTL_EMAIL_ADDR }}
         run: uv run pytest tests/
 
   build-and-publish:


### PR DESCRIPTION
Add ARTL_EMAIL_ADDR environment variable to the test step in the PyPI publishing workflow to match the configuration in the main testing action, fixing email-related test failures during PyPI publishing.

🤖 Generated with [Claude Code](https://claude.ai/code)