### PR TITLE
Add support for Supplementary Material retrieval (PubMed Central Open Access)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,10 +178,14 @@ local/claude-demo-windowing.txt:
 	@echo "🤖 Claude CLI: Get partial text using windowing"
 	claude --debug --verbose --mcp-config claude-mcp-config.json --dangerously-skip-permissions --print "Get characters 1000-3000 from the full text of DOI 10.1371/journal.pone.0000217" 2>&1 | tee $@
 
+local/claude-demo-supplementary-material.txt:
+	@echo "🤖 Claude CLI: Get supplementary material from PMC"
+	claude --debug --verbose --mcp-config claude-mcp-config.json --dangerously-skip-permissions --print "Get supplementary material for PMC7294781 file index 1" 2>&1 | tee $@
+
 # Clean up Claude demo output files
 clean-claude-demos:
 	rm -f local/claude-demo-*.txt
 
 # Run all Claude demos with cleanup (comprehensive meta-target)
-claude-demos-all: clean-claude-demos local/claude-demo-rhizosphere.txt local/claude-demo-get-paper-by-id.txt local/claude-demo-get-all-identifiers.txt local/claude-demo-full-text.txt local/claude-demo-pdf-to-markdown.txt local/claude-demo-windowing.txt
+claude-demos-all: clean-claude-demos local/claude-demo-rhizosphere.txt local/claude-demo-get-paper-by-id.txt local/claude-demo-get-all-identifiers.txt local/claude-demo-full-text.txt local/claude-demo-pdf-to-markdown.txt local/claude-demo-windowing.txt local/claude-demo-supplementary-material.txt
 	@echo "✅ All Claude demos completed! Check local/claude-demo-*.txt for output"

--- a/src/artl_mcp/main.py
+++ b/src/artl_mcp/main.py
@@ -16,10 +16,7 @@ from artl_mcp.tools import (
     # Search tools
     search_pubmed_for_pmids,
 )
-
-from artl_mcp.utils.pubmed_utils import (
-    get_pmc_supplemental_material
-)
+from artl_mcp.utils.pubmed_utils import get_pmc_supplemental_material
 
 try:
     __version__ = metadata.version("artl-mcp")
@@ -125,11 +122,13 @@ get_europepmc_pdf_as_markdown("10.1038/nature12373")
 get_europepmc_pdf_as_markdown("PMC3737249", method="hybrid", save_file=True)
 ```
 
-The above tools exclusively use Europe PMC and will never attempt to contact NCBI/PubMed APIs.
+The above tools exclusively use Europe PMC and will never attempt to contact
+NCBI/PubMed APIs.
 
 The following tools rely on an NCBI API:
 
-# Retrieve Supplemental Material as text from a PubMed Central Open Access article via it's PubMed Central ID:
+# Retrieve Supplemental Material as text from a PubMed Central Open Access
+# article via it's PubMed Central ID:
 get_pmc_supplemental_material("PMC7294781", 1)
 get_pmc_supplemental_material("PMC:7294781", 1)
 
@@ -195,7 +194,8 @@ get_pmc_supplemental_material("PMC:7294781", 1)
     # Other tools commented out to avoid NCBI API calls
     # mcp.tool(search_papers_by_keyword)
     # mcp.tool(search_recent_papers)
-    # The PubMed Central Supplemental Material API supports retrieval as text (more immediately useful than Europe PMC which uses binary files).
+    # The PubMed Central Supplemental Material API supports retrieval as text
+    # (more immediately useful than Europe PMC which uses binary files).
     mcp.tool(get_pmc_supplemental_material)
 
     return mcp

--- a/src/artl_mcp/main.py
+++ b/src/artl_mcp/main.py
@@ -17,6 +17,10 @@ from artl_mcp.tools import (
     search_pubmed_for_pmids,
 )
 
+from artl_mcp.utils.pubmed_utils import (
+    get_pmc_supplemental_material
+)
+
 try:
     __version__ = metadata.version("artl-mcp")
 except metadata.PackageNotFoundError:
@@ -121,7 +125,13 @@ get_europepmc_pdf_as_markdown("10.1038/nature12373")
 get_europepmc_pdf_as_markdown("PMC3737249", method="hybrid", save_file=True)
 ```
 
-All tools exclusively use Europe PMC and will never attempt to contact NCBI/PubMed APIs.
+The above tools exclusively use Europe PMC and will never attempt to contact NCBI/PubMed APIs.
+
+The following tools rely on an NCBI API:
+
+# Retrieve Supplemental Material as text from a PubMed Central Open Access article via it's PubMed Central ID:
+get_pmc_supplemental_material("PMC7294781", 1)
+get_pmc_supplemental_material("PMC:7294781", 1)
 
 """,
     )
@@ -185,6 +195,8 @@ All tools exclusively use Europe PMC and will never attempt to contact NCBI/PubM
     # Other tools commented out to avoid NCBI API calls
     # mcp.tool(search_papers_by_keyword)
     # mcp.tool(search_recent_papers)
+    # The PubMed Central Supplemental Material API supports retrieval as text (more immediately useful than Europe PMC which uses binary files).
+    mcp.tool(get_pmc_supplemental_material)
 
     return mcp
 

--- a/src/artl_mcp/utils/pubmed_utils.py
+++ b/src/artl_mcp/utils/pubmed_utils.py
@@ -1,9 +1,9 @@
+import html
+import json
 import logging
 import re
 
 import requests
-import json
-import html
 from bs4 import BeautifulSoup
 
 from artl_mcp.utils.conversion_utils import IdentifierConverter
@@ -340,6 +340,7 @@ def get_abstract_from_pubmed(pmid: str) -> str:
 
     return f"{title}\n\n{abstract}\n\nPMID:{pmid}"
 
+
 def list_pmcid_supplemental_material(pmcid: str | int) -> str:
     """Lists the Supplemental Material available for a PubMed Central article.
 
@@ -363,7 +364,10 @@ def list_pmcid_supplemental_material(pmcid: str | int) -> str:
     try:
         normalized_pmcid = IdentifierUtils.normalize_pmcid(pmcid, "raw")
     except IdentifierError as e:
-        logger.warning(f"Invalid PubMed Central ID for Supplemental Material listing: {pmcid} - {e}")
+        logger.warning(
+            f"Invalid PubMed Central ID for Supplemental Material listing: "
+            f"{pmcid} - {e}"
+        )
         return f"Error: Invalid PubMed Central ID format: {pmcid}"
 
     try:
@@ -385,6 +389,7 @@ def list_pmcid_supplemental_material(pmcid: str | int) -> str:
         return "{}"
 
     return text
+
 
 def get_pmc_supplemental_material(pmcid: str | int, idx: int | None = None) -> str:
     """Gets Supplemental Material for a PubMed Central Open Access article.
@@ -410,7 +415,10 @@ def get_pmc_supplemental_material(pmcid: str | int, idx: int | None = None) -> s
     try:
         normalized_pmcid = IdentifierUtils.normalize_pmcid(pmcid, "raw")
     except IdentifierError as e:
-        logger.warning(f"Invalid PubMed Central ID for Supplemental Material retrieval: {pmcid} - {e}")
+        logger.warning(
+            f"Invalid PubMed Central ID for Supplemental Material retrieval: "
+            f"{pmcid} - {e}"
+        )
         return f"Error: Invalid PubMed Central ID format: {pmcid}"
 
     if idx is not None and idx <= 0:
@@ -432,7 +440,11 @@ def get_pmc_supplemental_material(pmcid: str | int, idx: int | None = None) -> s
 
     text = response.text
 
-    if text is None or len(text) == 0 or text.startswith("[Error] : No result can be found."):
+    if (
+        text is None
+        or len(text) == 0
+        or text.startswith("[Error] : No result can be found.")
+    ):
         text = "No Supplementary Material is available."
 
     if text.startswith("["):

--- a/src/artl_mcp/utils/pubmed_utils.py
+++ b/src/artl_mcp/utils/pubmed_utils.py
@@ -391,7 +391,9 @@ def list_pmcid_supplemental_material(pmcid: str | int) -> str:
     return text
 
 
-def get_pmc_supplemental_material(pmcid: str | int, idx: int | None = None) -> str:
+def get_pmc_supplemental_material(
+    pmcid: str | int, idx: int | None = None, offset: int = 0, limit: int | None = None
+) -> str:
     """Gets Supplemental Material for a PubMed Central Open Access article.
 
     Supports multiple PubMed Central ID in the following input formats:
@@ -402,14 +404,16 @@ def get_pmc_supplemental_material(pmcid: str | int, idx: int | None = None) -> s
     Args:
         pmcid: PubMed Central ID in any supported format
         idx: The file index to retrieve
+        offset: Character offset to start from (default: 0)
+        limit: Maximum number of characters to return (default: None for all)
 
     Returns:
-        A Supplemental Material file.
+        A Supplemental Material file content, optionally windowed.
 
     Examples:
         >>> get_pmc_supplemental_material("PMC12345678", 1)
         'Supplementary Material...'
-        >>> get_pmc_supplemental_material("PMC:12345678", 1)
+        >>> get_pmc_supplemental_material("PMC:12345678", 1, offset=100, limit=500)
         'Supplementary Material...'
     """
     try:
@@ -459,5 +463,12 @@ def get_pmc_supplemental_material(pmcid: str | int, idx: int | None = None) -> s
         ]
         texts = [html.unescape(t) for t in texts]
         text = "\n".join(texts)
+
+    # Apply sliding window if requested
+    if offset > 0 or limit is not None:
+        if offset >= len(text):
+            return ""
+        end_pos = offset + limit if limit is not None else len(text)
+        text = text[offset:end_pos]
 
     return text

--- a/tests/test_pubmed_utils.py
+++ b/tests/test_pubmed_utils.py
@@ -271,6 +271,7 @@ def test_functions_handle_none_values():
     except (TypeError, AttributeError):
         pass  # Acceptable to raise error for None input
 
+
 # Supplementary Material retrieval tests
 @pytest.mark.external_api
 @pytest.mark.slow
@@ -285,6 +286,7 @@ def test_get_supplementary_material_from_pmc_none():
     assert not len(result) == 0
     assert result.startswith("No Supplementary Material is available.")
 
+
 # Supplementary Material retrieval tests
 @pytest.mark.external_api
 @pytest.mark.slow
@@ -298,6 +300,7 @@ def test_get_supplementary_material_from_pmc_all():
     assert result is not None
     assert not len(result) == 0
     assert not result.startswith("No Supplementary Material is available.")
+
 
 # Supplementary Material retrieval tests
 @pytest.mark.external_api

--- a/tests/test_pubmed_utils.py
+++ b/tests/test_pubmed_utils.py
@@ -270,3 +270,45 @@ def test_functions_handle_none_values():
         assert aupu.extract_doi_from_url(None) is None
     except (TypeError, AttributeError):
         pass  # Acceptable to raise error for None input
+
+# Supplementary Material retrieval tests
+@pytest.mark.external_api
+@pytest.mark.slow
+@skip_if_ncbi_offline
+def test_get_supplementary_material_from_pmc_none():
+    """Test Supplementary Material retrieval."""
+    # Use a PubMed Central ID known to not have Supplementary Material.
+    test_pmcid = "PMC1790863"
+    result = aupu.get_pmc_supplemental_material(test_pmcid)
+
+    assert result is not None
+    assert not len(result) == 0
+    assert result.startswith("No Supplementary Material is available.")
+
+# Supplementary Material retrieval tests
+@pytest.mark.external_api
+@pytest.mark.slow
+@skip_if_ncbi_offline
+def test_get_supplementary_material_from_pmc_all():
+    """Test Supplementary Material retrieval."""
+    # Use a PubMed Central ID known to have Supplementary Material.
+    test_pmcid = "PMC7294781"
+    result = aupu.get_pmc_supplemental_material(test_pmcid)
+
+    assert result is not None
+    assert not len(result) == 0
+    assert not result.startswith("No Supplementary Material is available.")
+
+# Supplementary Material retrieval tests
+@pytest.mark.external_api
+@pytest.mark.slow
+@skip_if_ncbi_offline
+def test_get_supplementary_material_from_pmc_one():
+    """Test Supplementary Material retrieval."""
+    # Use a PubMed Central ID known to have Supplementary Material.
+    test_pmcid = "PMC7294781"
+    result = aupu.get_pmc_supplemental_material(test_pmcid, 1)
+
+    assert result is not None
+    assert not len(result) == 0
+    assert not result.startswith("No Supplementary Material is available.")


### PR DESCRIPTION
Fixes #135 

Added Supplemental Material listing and retrieval (as plain text) via PMCID. Registered as one new tool in MCP.

Although Europe PMC has an endpoint for retrieving supplemental material, it returns files in their original binary format.

The NCBI PMC BioC API returns Supplemental Material in XML or JSON (used here), which is easily converted to plain text.
This endpoint can use PMID or PMCID. I chose to use only PMCID because only PubMed Central Open Access articles will have Supplemental Material available via this API.