### PR TITLE
Remove file saving from MCP tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@
 # Default target - use test-coverage for comprehensive CI/release checks
 all: clean install dev test-coverage format lint mypy deptry build doi-test-query search-test-query test-version
 
+no-tests: clean install dev format lint mypy deptry build doi-test-query search-test-query test-version
+
 # Install everything for development
 dev:
 	uv sync --group dev
@@ -164,39 +166,22 @@ local/claude-demo-get-all-identifiers.txt:
 	@echo "🤖 Claude CLI: Get all identifiers and links for PMID:23851394 using Europe PMC"
 	claude --debug --verbose --mcp-config claude-mcp-config.json --dangerously-skip-permissions --print "Get all available identifiers and access links for PMID:23851394 using Europe PMC" 2>&1 | tee $@
 
-# File saving demonstration targets
-local/claude-demo-search-with-save.txt:
-	@echo "🤖 Claude CLI: Search Europe PMC for CRISPR papers and save results to file"
-	claude --debug --verbose --mcp-config claude-mcp-config.json --dangerously-skip-permissions --print "Search Europe PMC for 5 CRISPR papers using core mode and save the results to a file. Tell me the exact filename where the results were saved." 2>&1 | tee $@
-
-local/claude-demo-paper-metadata-save.txt:
-	@echo "🤖 Claude CLI: Get paper metadata for DOI and save to file"
-	claude --debug --verbose --mcp-config claude-mcp-config.json --dangerously-skip-permissions --print "Get full paper metadata for DOI 10.1038/nature12373 from Europe PMC and save it to a file. Tell me the exact filename where the metadata was saved." 2>&1 | tee $@
-
-local/claude-demo-identifiers-save.txt:
-	@echo "🤖 Claude CLI: Get all identifiers for PMID and save to file"
-	claude --debug --verbose --mcp-config claude-mcp-config.json --dangerously-skip-permissions --print "Get all identifiers and access links for PMID 23851394 from Europe PMC and save to a file. Tell me the exact filename where the identifiers were saved." 2>&1 | tee $@
-
 local/claude-demo-full-text.txt:
-	@echo "🤖 Claude CLI: Get full text content in Markdown format and save to file"
-	claude --debug --verbose --mcp-config claude-mcp-config.json --dangerously-skip-permissions --print "Get the full text content for DOI 10.1371/journal.pone.0000217 from Europe PMC in Markdown format and save it to a file. Tell me exactly what sections were found and the filename where it was saved. Also show me the first few lines of the Markdown content." 2>&1 | tee $@
-
-local/claude-demo-pdf-download.txt:
-	@echo "🤖 Claude CLI: Download PDF from Europe PMC and save to file"
-	claude --debug --verbose --mcp-config claude-mcp-config.json --dangerously-skip-permissions --print "Download the PDF for DOI 10.1371/journal.pone.0000217 from Europe PMC and save it to a file. Tell me the exact filename where the PDF was saved and the file size." 2>&1 | tee $@
+	@echo "🤖 Claude CLI: Get full text content"
+	claude --debug --verbose --mcp-config claude-mcp-config.json --dangerously-skip-permissions --print "Get the full text for DOI 10.1371/journal.pone.0000217" 2>&1 | tee $@
 
 local/claude-demo-pdf-to-markdown.txt:
-	@echo "🤖 Claude CLI: Convert Europe PMC PDF to Markdown using streaming processing"
-	claude --debug --verbose --mcp-config claude-mcp-config.json --dangerously-skip-permissions --print "Convert the PDF for DOI 10.1371/journal.pone.0000217 from Europe PMC to Markdown format using streaming processing and save it to a file. Tell me the exact filename where the Markdown was saved, the processing method used, and show me a preview of the first few sections." 2>&1 | tee $@
+	@echo "🤖 Claude CLI: Convert PDF to Markdown"
+	claude --debug --verbose --mcp-config claude-mcp-config.json --dangerously-skip-permissions --print "Convert the PDF for DOI 10.1371/journal.pone.0000217 to Markdown" 2>&1 | tee $@
 
-local/claude-demo-windowing-offset-limit.txt:
-	@echo "🤖 Claude CLI: Demonstrate content windowing with offset and limit parameters"
-	claude --debug --verbose --mcp-config claude-mcp-config.json --dangerously-skip-permissions --print "Get the full text for DOI 10.1371/journal.pone.0000217 from Europe PMC, but use windowing to show only characters 1000-2000 (offset=1000, limit=1000). Also save the full content to a file and tell me how the windowing feature works." 2>&1 | tee $@
+local/claude-demo-windowing.txt:
+	@echo "🤖 Claude CLI: Get partial text using windowing"
+	claude --debug --verbose --mcp-config claude-mcp-config.json --dangerously-skip-permissions --print "Get characters 1000-3000 from the full text of DOI 10.1371/journal.pone.0000217" 2>&1 | tee $@
 
 # Clean up Claude demo output files
 clean-claude-demos:
 	rm -f local/claude-demo-*.txt
 
 # Run all Claude demos with cleanup (comprehensive meta-target)
-claude-demos-all: clean-claude-demos local/claude-demo-rhizosphere.txt local/claude-demo-get-paper-by-id.txt local/claude-demo-get-all-identifiers.txt local/claude-demo-full-text.txt local/claude-demo-pdf-download.txt local/claude-demo-pdf-to-markdown.txt local/claude-demo-windowing-offset-limit.txt local/claude-demo-search-with-save.txt local/claude-demo-paper-metadata-save.txt local/claude-demo-identifiers-save.txt
+claude-demos-all: clean-claude-demos local/claude-demo-rhizosphere.txt local/claude-demo-get-paper-by-id.txt local/claude-demo-get-all-identifiers.txt local/claude-demo-full-text.txt local/claude-demo-pdf-to-markdown.txt local/claude-demo-windowing.txt
 	@echo "✅ All Claude demos completed! Check local/claude-demo-*.txt for output"

--- a/README.md
+++ b/README.md
@@ -52,37 +52,34 @@ uvx artl-cli search-papers-by-keyword --query "CRISPR gene editing" --max-result
 - Related paper discovery through citation networks
 
 ### 💾 **File Management**
-- **Save path reporting** - tools tell you exactly where files were saved
-- **Content size management** - large content (>100KB) automatically truncated for LLM responses
+- **MCP Mode**: Returns data directly without file saving (optimal for AI assistants)
+- **CLI Mode**: Full file saving with path reporting and content management
+- **Content size management** - large content automatically handled appropriately
 - **Memory-efficient streaming** for large files (PDFs, datasets)  
-- **Backward compatible** - existing code continues to work
 - **Cross-platform filename sanitization**
-- **Multiple output formats** (JSON, TXT, CSV, PDF)
-- **Configurable directories** and temp file management
+- **Multiple output formats** (JSON, TXT, CSV, PDF) in CLI mode
+- **Configurable directories** and temp file management in CLI mode
 
 ## Available MCP Tools
 
 When running as an MCP server, you get access to 32 tools organized into categories:
 
-### 🔄 **Enhanced Return Values**
+### 🔄 **MCP vs CLI Mode Differences**
 
-All file-saving tools now return **structured data** with save path information:
+**MCP Mode** (AI assistants): Returns data directly without file saving:
+```json
+{
+  "data": { /* tool-specific content */ },
+  "mcp_mode": true,
+  "note": "Data returned directly - use CLI for file saving"
+}
+```
 
+**CLI Mode** (command line): Full file saving with path reporting:
 ```json
 {
   "data": { /* tool-specific content */ },
   "saved_to": "/path/to/saved/file.json"
-}
-```
-
-**Text-based tools** include content size management:
-
-```json
-{
-  "content": "Full or truncated content...",
-  "saved_to": "/path/to/saved/file.txt",
-  "windowed": false,
-  "content_length": 45678
 }
 ```
 
@@ -155,13 +152,15 @@ export ARTL_EMAIL_ADDR="researcher@university.edu"
 
 See [USERS.md](USERS.md#email-configuration-for-literature-access) for comprehensive configuration instructions.
 
-### File Output
-Configure where files are saved:
+### File Output (CLI Mode Only)
+Configure where files are saved when using CLI commands:
 ```bash
 export ARTL_OUTPUT_DIR="~/Papers"           # Default: ~/Documents/artl-mcp
 export ARTL_TEMP_DIR="/tmp/my-artl-temp"    # Default: system temp + artl-mcp
 export ARTL_KEEP_TEMP_FILES=true            # Default: false
 ```
+
+**Note**: MCP mode returns data directly without file saving.
 
 ## Supported Identifier Formats
 

--- a/src/artl_mcp/main.py
+++ b/src/artl_mcp/main.py
@@ -25,7 +25,6 @@ from artl_mcp.tools import (
     search_europepmc_papers as _search_europepmc_papers,
 )
 from artl_mcp.tools import (
-    # Search tools
     search_pubmed_for_pmids,
 )
 
@@ -39,7 +38,29 @@ except metadata.PackageNotFoundError:
 def search_europepmc_papers(
     keywords: str, max_results: int = 10, result_type: str = "lite"
 ):
-    """MCP wrapper - Search Europe PMC without file saving."""
+    """
+    Search Europe PMC for papers without saving results to a file.
+
+    This function wraps the `_search_europepmc_papers` function and disables
+    file saving. It retrieves metadata about papers matching the given keywords.
+
+    Args:
+        keywords (str): The search query string containing keywords to look for.
+        max_results (int, optional): The maximum number of results to return.
+            Defaults to 10.
+        result_type (str, optional): The type of results to retrieve.
+            Options include "lite" (basic metadata)
+            and "core" (detailed metadata). Defaults to "lite".
+
+    Returns:
+        list[dict]: A list of dictionaries, where each dictionary contains metadata
+        about a paper matching the search query.
+
+    Example:
+        >>> results = search_europepmc_papers("machine learning", max_results=5)
+        >>> for paper in results:
+        ...     print(paper["title"])
+    """
     return _search_europepmc_papers(
         keywords=keywords,
         max_results=max_results,
@@ -89,6 +110,7 @@ def get_europepmc_pdf(identifier: str):
 
     # Remove any file paths from the result since we're not saving
     if result and "saved_to" in result:
+        result = result.copy()  # Create a shallow copy before modifying
         result["saved_to"] = None
         # Add a note that this is MCP mode
         result["mcp_mode"] = True


### PR DESCRIPTION
- Add MCP wrapper functions in main.py that disable file saving
- Update README.md to distinguish MCP mode (no saving) vs CLI mode (full saving)
- Simplify Makefile Claude demos and add windowing demo
- Update MCP instructions to reflect no file saving behavior
- Core tools.py functions unchanged for backward compatibility

🤖 Generated with [Claude Code](https://claude.ai/code)