### PR TITLE
Remove get_europepmc_pdf tool from MCP server

### DIFF
--- a/src/artl_mcp/main.py
+++ b/src/artl_mcp/main.py
@@ -123,7 +123,7 @@ def create_mcp():
         instructions="""
 Europe PMC Literature Discovery and ID Translation Tools
 
-This MCP server provides FIVE TOOLS for scientific literature discovery and
+This MCP server provides SIX TOOLS for scientific literature discovery and
 identifier translation using Europe PMC exclusively. No NCBI/PubMed APIs are accessed.
 
 ## Tool Selection Guide


### PR DESCRIPTION
The get_europepmc_pdf tool was download-oriented and incompatible with MCP's no-file-saving policy. The get_europepmc_pdf_as_markdown tool provides the same functionality in a streaming-oriented manner suitable for MCP usage.

🤖 Generated with [Claude Code](https://claude.ai/code)