### PR TITLE
Fix broken claude-demos-all Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,10 @@ local/claude-demo-windowing.txt:
 	@echo "🤖 Claude CLI: Get partial text using windowing"
 	claude --debug --verbose --mcp-config claude-mcp-config.json --dangerously-skip-permissions --print "Get characters 1000-3000 from the full text of DOI 10.1371/journal.pone.0000217" 2>&1 | tee $@
 
+local/claude-demo-pdf-to-markdown.txt:
+	@echo "🤖 Claude CLI: Convert Europe PMC PDF to Markdown"
+	claude --debug --verbose --mcp-config claude-mcp-config.json --dangerously-skip-permissions --print "Convert the PDF for PMC3737249 to Markdown format" 2>&1 | tee $@
+
 local/claude-demo-supplementary-material.txt:
 	@echo "🤖 Claude CLI: Get supplementary material from PMC"
 	claude --debug --verbose --mcp-config claude-mcp-config.json --dangerously-skip-permissions --print "Get supplementary material for PMC7294781 file index 1" 2>&1 | tee $@


### PR DESCRIPTION
Fixes #217

## Problem

The `claude-demos-all` Makefile target failed because it referenced a missing prerequisite:
```makefile
claude-demos-all: ... local/claude-demo-pdf-to-markdown.txt ...
```

But the `local/claude-demo-pdf-to-markdown.txt` target was not defined.

## Solution

Added the missing target that tests the `get_europepmc_pdf_as_markdown` MCP tool:

```makefile
local/claude-demo-pdf-to-markdown.txt:
	@echo "🤖 Claude CLI: Convert Europe PMC PDF to Markdown"
	claude --debug --verbose --mcp-config claude-mcp-config.json \
	  --dangerously-skip-permissions --print \
	  "Convert the PDF for PMC3737249 to Markdown format" 2>&1 | tee $@
```

## Testing

✅ Tested manually with success:
- Converted PMC3737249 PDF (7 pages, 39.8 KB) in ~37 seconds
- Tables extracted and formatted correctly
- Bibliography preserved with proper structure
- Full MCP server PDF conversion pipeline validated

✅ Now `make claude-demos-all` runs without errors

## Impact

- Unbreaks the comprehensive MCP demo testing workflow
- Enables automated validation of PDF-to-Markdown functionality
- Completes the suite of Claude CLI integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)